### PR TITLE
update the go-dev image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHORT_NAME := envtpl
 REPO_PATH := github.com/arschles/${SHORT_NAME}
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.3.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}


### PR DESCRIPTION
this commit moves us to go 1.6, and Fixes #4
