### PR TITLE
Allowing templates to be in other directories

### DIFF
--- a/env.go
+++ b/env.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+func collectEnv() map[string]string {
+	envMap := make(map[string]string)
+	envStrs := os.Environ()
+	for _, envStr := range envStrs {
+		spl := strings.SplitN(envStr, "=", 2)
+		if len(spl) != 2 {
+			continue
+		}
+		envMap[spl[0]] = spl[1]
+	}
+	return envMap
+}

--- a/env_test.go
+++ b/env_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/arschles/assert"
+)
+
+func TestCollectEnv(t *testing.T) {
+	envMap := collectEnv()
+	pwd, ok := envMap["PWD"]
+	assert.True(t, ok, "'PWD' not found in the env")
+	wd, err := os.Getwd()
+	assert.NoErr(t, err)
+	assert.Equal(t, pwd, wd, "working dir")
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 9a13a56fb3837fbdde3274ee4331ca1e072849f06007a1f1bfaa7669ccc3c05d
-updated: 2016-03-04T17:51:40.938237512Z
+hash: 3de6518c74a099c6b494cac024246f76fbb18fb187cb85cd0b35e7d2a9226433
+updated: 2016-04-22T14:14:50.485712326-07:00
 imports:
 - name: github.com/aokoli/goutils
   version: 9c37978a95bd5c709a15883b6242714ea6709e64
+- name: github.com/arschles/assert
+  version: d21ecd4884be33397d1298c3738b2b4937c7f499
 - name: github.com/Masterminds/sprig
-  version: fd057ca403105755181f84645696d705a58852dd
+  version: e6494bc7e81206ba6db404d2fd96500ffc453407
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,4 @@
 package: main
 import:
 - package: github.com/Masterminds/sprig
+- package: github.com/arschles/assert

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	template "text/template"
 
@@ -20,23 +19,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	tpl, err := template.New(*in).Funcs(sprig.TxtFuncMap()).ParseFiles(*in)
+	tpl, err := template.ParseFiles(*in)
 	if err != nil {
 		fmt.Printf("Error: parsing template %s (%s)\n", *in, err)
 		os.Exit(1)
 	}
 
-	envMap := make(map[string]string)
-	envStrs := os.Environ()
-	for _, envStr := range envStrs {
-		spl := strings.SplitN(envStr, "=", 2)
-		if len(spl) != 2 {
-			continue
-		}
-		envMap[spl[0]] = spl[1]
-	}
+	envMap := collectEnv()
 
-	if err := tpl.Execute(os.Stdout, envMap); err != nil {
+	if err := tpl.Funcs(sprig.TxtFuncMap()).Execute(os.Stdout, envMap); err != nil {
 		fmt.Printf("Rendering template (%s)", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Fixes https://github.com/arschles/envtpl/issues/9

This fix enables `envtpl` to parse and output template files from other locations on the filesystem besides the current working dir. See example below.

``` console
ENG000656:Desktop aaronschlesinger$ envtpl -in $GOPATH/src/github.com/arschles/envtpl/testdata/pwd.tpl
The current working directory is /Users/aaronschlesinger/Desktop
```
