### PR TITLE
Render errors to stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,21 +14,21 @@ func main() {
 	in := flag.String("in", "", "the template to render")
 	flag.Parse()
 	if *in == "" {
-		fmt.Println("Error: the input file was empty")
+		fmt.Fprintln(os.Stderr, "Error: the input file was empty")
 		flag.Usage()
 		os.Exit(1)
 	}
 
 	tpl, err := template.ParseFiles(*in)
 	if err != nil {
-		fmt.Printf("Error: parsing template %s (%s)\n", *in, err)
+		fmt.Fprintf(os.Stderr, "Error: parsing template %s (%s)\n", *in, err)
 		os.Exit(1)
 	}
 
 	envMap := collectEnv()
 
 	if err := tpl.Funcs(sprig.TxtFuncMap()).Execute(os.Stdout, envMap); err != nil {
-		fmt.Printf("Rendering template (%s)", err)
+		fmt.Fprintf(os.Stderr, "Rendering template (%s)", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
If the pattern is to run `envtpl -in file > out`
The current error logging will get written to a file vs going to stderr which makes it harder to debug
